### PR TITLE
Check PSRCHIVE API for multi-version compatability

### DIFF
--- a/clfd/core.py
+++ b/clfd/core.py
@@ -112,7 +112,10 @@ class DataCube(object):
             DataCube instance wrapping Stokes I data.
         """
         if type(archive) == str:
-            archive = psrchive.Archive_load(archive)
+	    	if hasattr(psrchive, "Archive_load"):
+	        	archive = psrchive.Archive_load(archive)
+	    	elif hasattr(psrchive, "Archive.load"):
+	        	archive = psrchive.Archive.load(archive)
 
         # Extract Stokes I only
         # Data shape is (n_subints, n_channels, n_phase_bins)

--- a/clfd/core.py
+++ b/clfd/core.py
@@ -113,10 +113,10 @@ class DataCube(object):
         """
         if type(archive) == str:
             if hasattr(psrchive, "Archive_load"):
-                archive = psrchive.Archive_load(fname)
-        	else:
+                archive = psrchive.Archive_load(archive)
+            else:
                 try:
-                    archive = psrchive.Archive.load(fname)
+                    archive = psrchive.Archive.load(archive)
                 except AttributeError:
                     raise
 	    # If neither of the above resolve, there is a

--- a/clfd/core.py
+++ b/clfd/core.py
@@ -113,9 +113,14 @@ class DataCube(object):
         """
         if type(archive) == str:
 	    	if hasattr(psrchive, "Archive_load"):
-	        	archive = psrchive.Archive_load(archive)
-	    	elif hasattr(psrchive, "Archive.load"):
-	        	archive = psrchive.Archive.load(archive)
+            	archive = psrchive.Archive_load(fname)
+        	else:
+            	try:
+                	archive = psrchive.Archive.load(fname)
+            	except AttributeError:
+                	raise
+	        # If neither of the above resolve, there is a 
+	        # PSRCHIVE installation problem.
 
         # Extract Stokes I only
         # Data shape is (n_subints, n_channels, n_phase_bins)

--- a/clfd/core.py
+++ b/clfd/core.py
@@ -112,15 +112,15 @@ class DataCube(object):
             DataCube instance wrapping Stokes I data.
         """
         if type(archive) == str:
-	    	if hasattr(psrchive, "Archive_load"):
-            	archive = psrchive.Archive_load(fname)
+            if hasattr(psrchive, "Archive_load"):
+                archive = psrchive.Archive_load(fname)
         	else:
-            	try:
-                	archive = psrchive.Archive.load(fname)
-            	except AttributeError:
-                	raise
-	        # If neither of the above resolve, there is a 
-	        # PSRCHIVE installation problem.
+                try:
+                    archive = psrchive.Archive.load(fname)
+                except AttributeError:
+                    raise
+	    # If neither of the above resolve, there is a
+	    # PSRCHIVE installation problem.
 
         # Extract Stokes I only
         # Data shape is (n_subints, n_channels, n_phase_bins)

--- a/clfd/core.py
+++ b/clfd/core.py
@@ -112,15 +112,13 @@ class DataCube(object):
             DataCube instance wrapping Stokes I data.
         """
         if type(archive) == str:
-            if hasattr(psrchive, "Archive_load"):
+            try:
                 archive = psrchive.Archive_load(archive)
-            else:
-                try:
-                    archive = psrchive.Archive.load(archive)
-                except AttributeError:
-                    raise
+            except AttributeError:
+                archive = psrchive.Archive.load(archive)
 	    # If neither of the above resolve, there is a
-	    # PSRCHIVE installation problem.
+	    # PSRCHIVE installation problem and we want to
+        # terminate execution anyway.
 
         # Extract Stokes I only
         # Data shape is (n_subints, n_channels, n_phase_bins)

--- a/clfd/interfaces/core.py
+++ b/clfd/interfaces/core.py
@@ -99,15 +99,13 @@ class PsrchiveInterface(Interface):
 
     @staticmethod
     def load(fname):
-        if hasattr(psrchive, "Archive_load"):
+        try:
             archive = psrchive.Archive_load(fname)
-        else:
-            try:
-                archive = psrchive.Archive.load(fname)
-            except AttributeError:
-                raise
-        # If neither of the above resolve, there is a 
-        # PSRCHIVE installation problem.
+        except AttributeError:
+            archive = psrchive.Archive.load(fname)
+	    # If neither of the above resolve, there is a
+	    # PSRCHIVE installation problem and we want to
+        # terminate execution anyway.
         
         return archive, DataCube.from_psrchive(archive)
 

--- a/clfd/interfaces/core.py
+++ b/clfd/interfaces/core.py
@@ -99,7 +99,16 @@ class PsrchiveInterface(Interface):
 
     @staticmethod
     def load(fname):
-        archive = psrchive.Archive_load(fname)
+        if hasattr(psrchive, "Archive_load"):
+            archive = psrchive.Archive_load(fname)
+        else:
+            try:
+                archive = psrchive.Archive.load(fname)
+            except AttributeError:
+                raise
+        # If neither of the above resolve, there is a 
+        # PSRCHIVE installation problem.
+        
         return archive, DataCube.from_psrchive(archive)
 
     @staticmethod


### PR DESCRIPTION
At some point the API for loading a PSRCHIVE archive file has changed, as identified in #3 

These changes fix that, first by checking the the "classic" `psrchive.Archive_load()` method is available, and then by trying the newer `psrchive.Archive.load()` method. If neither of those methods work, an `AttributeError` is now thrown, since it implies there is something wrong with the PSRCHIVE Python installation. 

P.S. We also noticed some `pandas>=3.0` deprecation warnings (that don't appear to be breaking, but might warrant attention in future). 
```
/software/local/lib/python3.12/dist-packages/clfd/report.py:209: FutureWarning: Starting with pandas version 3.0 all arguments of to_hdf except for the argument 'path_or_buf' will be keyword-only.
  self.features.to_hdf(store, 'features')
/software/local/lib/python3.12/dist-packages/clfd/report.py:210: FutureWarning: Starting with pandas version 3.0 all arguments of to_hdf except for the argument 'path_or_buf' will be keyword-only.
  self.stats.to_hdf(store, 'stats')
/software/local/lib/python3.12/dist-packages/clfd/report.py:214: FutureWarning: Starting with pandas version 3.0 all arguments of to_hdf except for the argument 'path_or_buf' will be keyword-only.
  pandas.DataFrame(self.profmask).to_hdf(store, 'profmask')
/software/local/lib/python3.12/dist-packages/clfd/report.py:215: FutureWarning: Starting with pandas version 3.0 all arguments of to_hdf except for the argument 'path_or_buf' will be keyword-only.
  pandas.DataFrame(self.frequencies).to_hdf(store, 'frequencies')
/software/local/lib/python3.12/dist-packages/clfd/report.py:216: FutureWarning: Starting with pandas version 3.0 all arguments of to_hdf except for the argument 'path_or_buf' will be keyword-only.
  pandas.DataFrame(self.zap_channels).to_hdf(store, 'zap_channels')
```