### PR TITLE
if input data have state = PPQQ or Coherence, then add pol[0] and pol[1]

### DIFF
--- a/clfd/archive_handler.py
+++ b/clfd/archive_handler.py
@@ -25,9 +25,15 @@ class ArchiveHandler:
     def data_cube(self) -> NDArray:
         """
         Return the archive data as a 3-dimensional numpy array of shape
-        (num_subints, num_chans, num_bins). Only Stokes I data is read.
+        (num_subints, num_chans, num_bins). Only Stokes I data is used.
         """
-        return self._archive.get_data()[:, 0, :, :]
+        data = self._archive.get_data()[:, 0, :, :]
+
+        state = self._archive.get_state();
+        if state == 'Coherence' or state == 'PPQQ':
+            data += self._archive.get_data()[:, 1, :, :]
+
+        return data
 
     def apply_profile_mask(self, mask: NDArray):
         """


### PR DESCRIPTION
To date, clfd has assumed that pol[0] is equal to the total intensity and searched for RFI only there.
This fix updates clfd to check for the polarization state of the input data and, if it is PPQQ or Coherence, then pol[0] and pol[1] are added together before searching for RFI in the result.